### PR TITLE
Getting Started includes Fetch Assets instructions

### DIFF
--- a/operations/gettingstarted/README.md
+++ b/operations/gettingstarted/README.md
@@ -19,7 +19,7 @@ git clone https://{yourusername}@bitbucket.org/livestyled-dev/frontier.ios.git
 ## Perform Pre-Build Configuration
 
 ### Requirements
-* (If building client apps) Access to [Frame](https://frame.realifetech.com/)
+* If you wish to build a client's app, you will need access to [Frame](https://frame.realifetech.com/), or to know the client's app code.
 
 ### Instructions
 
@@ -27,11 +27,12 @@ Navigate to the project's scripts directory
 ```
 cd ./scripts
 ```
-Run the fetch assets script with the default configuration
+Run the fetch assets script
 ```
 bash fetch_assets.sh
 ```
-or, if you wish to build for a specific client (using their feature activations, styles, endpoints etc), look up their 'app code' on Frame and pass it into the fetch assets script:
+
+The above a command will fetch the platform (or default) configuration for the app. If you wish to build for a specific client (using their feature activations, styles, endpoints etc), look up their 'app code' on Frame and pass it into the fetch assets script:
 ```
 bash fetch_assets.sh APP_CODE
 ```
@@ -66,14 +67,4 @@ pod install --repo update
 ### To change the environment that the app points to (staging or release):
 1. Within Xcode, select **Product > Scheme > Edit Scheme**.
 2. Within the Run scheme, choose either Staging or Release as the build configuration
-3. Run the app
-
-### To manually change the endpoints that the app points to:
-1. Within Xcode, open **Environments.plist**
-2. Change the base URL for the scheme you are running (e.g. **concertLiveAPIBaseURLV3**)
-3. Run the app
-
-### To change the enabled features:
-1. Within Xcode, open **AppConfig.plist**
-2. Change the the value for the feature you wish to enable or disable
 3. Run the app

--- a/operations/gettingstarted/README.md
+++ b/operations/gettingstarted/README.md
@@ -16,6 +16,25 @@ or HTTPS:
 ```
 git clone https://{yourusername}@bitbucket.org/livestyled-dev/frontier.ios.git
 ```
+## Perform Pre-Build Configuration
+
+### Requirements
+* (If building client apps) Access to [Frame](https://frame.realifetech.com/)
+
+### Instructions
+
+Navigate to the project's scripts directory
+```
+cd ./scripts
+```
+Run the fetch assets script with the default configuration
+```
+bash fetch_assets.sh
+```
+or, if you wish to build for a specific client (using their feature activations, styles, endpoints etc), look up their 'app code' on Frame and pass it into the fetch assets script:
+```
+bash fetch_assets.sh APP_CODE
+```
 
 ## Installing dependencies
 
@@ -33,24 +52,10 @@ If you run into issues when switching between brances with different pods, you m
 pod install --repo update
 ```
 
-## Switching between branches/apps
-Fetch all branches using:
-```
-git fetch
-```
-Check out a branch using:
-```
-git checkout {branchname}
-```
-Reset changes using (you should do this when finished, and when switching branches):
-```
-git checkout .
-```
-
 ## Running the project
 
 ### Requirements
-- XCode 10.2.1
+- XCode 12.4
 
 ### Instructions
 1. Open the .workspace file in the project's directory

--- a/operations/gettingstarted/README.md
+++ b/operations/gettingstarted/README.md
@@ -19,6 +19,8 @@ git clone https://{yourusername}@bitbucket.org/livestyled-dev/frontier.ios.git
 ## Perform Pre-Build Configuration
 
 ### Requirements
+* [ImageMagik](https://imagemagick.org/script/download.php#macosx)
+* Python 2.7 (if on BigSur, consider pyenv)
 * If you wish to build a client's app, you will need access to [Frame](https://frame.realifetech.com/), or to know the client's app code.
 
 ### Instructions
@@ -52,7 +54,7 @@ If you run into issues when switching between brances with different pods, you m
 ```
 pod install --repo update
 ```
-Note, if you run the install command from outside the root, you may see the following error: `Invalid Podfile file: cannot load such file -- Scripts/DynamicModules.rb`. To fix this, in your terminal navigate back to the project root and run `$ pod install` again.
+Note, if you run the install command from outside the project root directory, you may see the following error: `Invalid Podfile file: cannot load such file -- Scripts/DynamicModules.rb`. To fix this, in your terminal navigate back to the project root and run `$ pod install` again.
 
 ## Running the project
 

--- a/operations/gettingstarted/README.md
+++ b/operations/gettingstarted/README.md
@@ -44,7 +44,7 @@ bash fetch_assets.sh APP_CODE
 - The [CocoaPods CLI](https://cocoapods.org)
 
 ### Instructions
-Inside the project's directory, run:
+Inside the project's root directory, run:
 ```
 pod install
 ```
@@ -52,6 +52,7 @@ If you run into issues when switching between brances with different pods, you m
 ```
 pod install --repo update
 ```
+Note, if you run the install command from outside the root, you may see the following error: `Invalid Podfile file: cannot load such file -- Scripts/DynamicModules.rb`. To fix this, in your terminal navigate back to the project root and run `$ pod install` again.
 
 ## Running the project
 
@@ -67,4 +68,14 @@ pod install --repo update
 ### To change the environment that the app points to (staging or release):
 1. Within Xcode, select **Product > Scheme > Edit Scheme**.
 2. Within the Run scheme, choose either Staging or Release as the build configuration
+3. Run the app
+
+### To manually change the endpoints that the app points to:
+1. Within Xcode, open **Environments.plist**
+2. Change the base URL for the scheme you are running (e.g. **concertLiveAPIBaseURLV3**)
+3. Run the app
+
+### To change the enabled features:
+1. Within Xcode, open **AppConfig.plist**
+2. Change the the value for the feature you wish to enable or disable
 3. Run the app

--- a/operations/gettingstarted/README.md
+++ b/operations/gettingstarted/README.md
@@ -59,7 +59,7 @@ Note, if you run the install command from outside the project root directory, yo
 ## Running the project
 
 ### Requirements
-- XCode 12.4
+- Xcode 12.4
 
 ### Instructions
 1. Open the .workspace file in the project's directory


### PR DESCRIPTION
* Instructions added for fetching assets from Frame (it's a required step, there was no documentation)
* Switching branches section removed (we no longer have client branches, and this is basic git instruction)
* Updated version of Xcode
* Removed instructions on endpoint & feature configuration (has been replaced by frame)

I believe it would be good to add some instructions on how one can toggle feature activations etc using Frame. For example, if there is an issue with a Client build, how can an engineer debug the feature activations being used.

I believe it would be good to add some information about what the difference between a debug, staging, and release environment configurations and when an engineer should use them.